### PR TITLE
Set WBP_ as prefered prefix for Widget Blueprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ When naming an asset use these tables to determine the prefix and suffix to use 
 | Skeletal Mesh           | SK_        |            |                                  |
 | Texture                 | T_         | _?         | See [Textures](#anc-textures)    |
 | Particle System         | PS_        |            |                                  |
-| Widget Blueprint        | WB_ or WBP_|            | Pick only one. Prefer WB_.       |
+| Widget Blueprint        | WBP_ or WB_|            | Pick only one. Prefer WBP_.      |
 
 <a name="anc-animations"></a>
 <a name="1.2.2"></a>
@@ -223,7 +223,7 @@ When naming an asset use these tables to determine the prefix and suffix to use 
 | Blueprint Macro Library | BPML_      |            | Do not use macro libraries if possible. |
 | Enumeration             | E          |            | No underscore.                   |
 | Structure               | F or S     |            | No underscore.                   |
-| Widget Blueprint        | WB_ or WBP_|            | Pick only one. Prefer WB_.       |
+| Widget Blueprint        | WBP_ or WB_|            | Pick only one. Prefer WBP_.      |
 
 <a name="anc-materials"></a>
 <a name="1.2.5"></a>
@@ -343,7 +343,7 @@ Packing 4 channels of data into a texture (RGBA) is not recommended except for a
 | Font                    | Font_      |            |                                  |
 | Slate Brush             | Brush_     |            |                                  |
 | Slate Widget Style      | Style_     |            |                                  |
-| Widget Blueprint        | WB_ or WBP_|            | Pick only one. Prefer WB_.       |
+| Widget Blueprint        | WBP_ or WB_|            | Pick only one. Prefer WBP_.      |
 
 <a name="anc-effects"></a>
 <a name="1.2.12"></a>


### PR DESCRIPTION
As described in #1 :

- the BP letters are included in all blueprint-related things. Promoting WBP_ prefix will lead to more consistent style