### PR TITLE
Added "BC_" prefix for Blueprintable Actor and Scene Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ Packing 4 channels of data into a texture (RGBA) is not recommended except for a
 | Asset Type              | Prefix     | Suffix     | Notes                            |
 | ----------------------- | ---------- | ---------- | -------------------------------- |
 | Animated Vector Field   | VFA_       |            |                                  |
+| Blueprintable Component | BC_        |            |                                  |
 | Camera Anim             | CA_        |            |                                  |
 | Color Curve             | Curve_     | _Color     |                                  |
 | Curve Table             | Curve_     | _Table     |                                  |


### PR DESCRIPTION
Proposing to use the BC_ prefix for blueprintable actor and scene components.  I noticed that these were not mentioned anywhere at all, so I figured it made sense to add it to the Miscellaneous list.