### PR TITLE
Add _M suffix for Metallic textures

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ When naming an asset use these tables to determine the prefix and suffix to use 
 | Texture (Emissive)      | T_         | _E         |                                  |
 | Texture (Mask)          | T_         | _M         |                                  |
 | Texture (Specular)      | T_         | _S         |                                  |
+| Texture (Metallic)      | T_         | _M         |                                  |
 | Texture (Packed)        | T_         | _*         | See notes below about [packing](#anc-textures-packing). |
 | Texture Cube            | TC_        |            |                                  |
 | Media Texture           | MT_        |            |                                  |


### PR DESCRIPTION
C is for conductor, since M is already taken by Mask. Fixes issue #32.