### PR TITLE
Remove link to https://gamemak.in, as it has an expired certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Gamemakin](https://gamemak.in) UE4 Style Guide() {
+# Gamemakin UE4 Style Guide() {
 
 *A mostly reasonable approach to Unreal Engine 4*
 


### PR DESCRIPTION
The invalid cert causes browsers to show a nasty gram.

Fixes #30.