### PR TITLE
Update linter plugin URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Heavily inspired by the [Airbnb Javascript Style Guide](https://github.com/airbn
 
 ## Unreal Engine 4 Linter Plugin
 
-An automated method of checking your project against this style guide is available for purchase at [the Unreal Engine marketplace](https://www.unrealengine.com/marketplace/linter). This plugin's source code will eventually be free, but in order to use with UE4 without building the engine from source code, please use the marketplace version.
+An automated method of checking your project against this style guide is available for free at [the Unreal Engine marketplace](https://www.unrealengine.com/marketplace/linter-v2). In order to use with UE4 without building the engine from source code, please use the marketplace version.
 
 ## Linter and Style Guide Documentation
 


### PR DESCRIPTION
Updated the marketplace URL of the newer linter v2 plugin (v1 no longer available). Also updated the language for this section since v2 of the linter is free.