### PR TITLE
Add prefix for Control Rig

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ When naming an asset, use these tables to determine the prefix and suffix to use
 | Morph Target            | MT_        |            |                                  |
 | Paper Flipbook          | PFB_       |            |                                  |
 | Rig                     | Rig_       |            |                                  |
+| Control Rig             | CR_        |            |                                  |
 | Skeletal Mesh           | SK_        |            |                                  |
 | Skeleton                | SKEL_      |            |                                  |
 


### PR DESCRIPTION
TBH, I'm kinda conflicted to use `_CtrlRig` suffix instead, but figured out the suffix could be obscured by long name or small icons in Content Browser, hence settling for the `CR_` prefix.