### PR TITLE
Update V2 branch readme to UE5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# [Gamemakin](https://gamemak.in) UE4 Style Guide Version 2() {
+# [Gamemakin](https://gamemak.in) UE5 Style Guide Version 2() {
 
 # THIS IS A DRAFT
 
 This is a draft of version 2. All work on version 2 of this style guide will be on this branch. Please feel free to commit any form of contribution in the form of a pull request, even if they are just ideas that still need to be solved but at least move the needle forward.
 
-*A mostly reasonable approach to Unreal Engine 4*
+*A mostly reasonable approach to Unreal Engine 5*
 
 Heavily inspired by the [Airbnb Javascript Style Guide](https://github.com/airbnb/javascript).
 
@@ -14,7 +14,6 @@ Heavily inspired by the [Airbnb Javascript Style Guide](https://github.com/airbn
 
 This repo is now located at https://github.com/Allar/ue5-style-guide. The default branch of this repository has been renamed `main`.
 
-## This is currently for UE4. For UE5/v2, see the v2 branch.
 ## Linter and Style Guide Documentation
 
 More technical documentation regarding Linter and the Style Guide can be found at our [ReadTheDocs](https://ue4-style-guide.readthedocs.io/en/latest/) page.


### PR DESCRIPTION
The V2 branch is for UE5, but the readme still refers to UE4 - so this fixes that to align.

Also - given the whole repo is now called "ue5-style-guide" and UE5 is released, will V2 become the default `main` soon?